### PR TITLE
Use global vertex and index buffers that are only bound once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "0.12.0"
-source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#c6d9f2ea07173cde2e03677eae9ec2b19f759bde"
+source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#77218e3bf2883765da02b33f35a63e61bdbbc4ab"
 dependencies = [
  "arrayvec",
  "js-sys",
@@ -1475,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.12.0"
-source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#c6d9f2ea07173cde2e03677eae9ec2b19f759bde"
+source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#77218e3bf2883765da02b33f35a63e61bdbbc4ab"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -1491,6 +1497,7 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "thiserror",
+ "web-sys",
  "wgpu-hal",
  "wgpu-types",
 ]
@@ -1498,8 +1505,9 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.12.0"
-source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#c6d9f2ea07173cde2e03677eae9ec2b19f759bde"
+source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#77218e3bf2883765da02b33f35a63e61bdbbc4ab"
 dependencies = [
+ "android-properties",
  "arrayvec",
  "ash",
  "bit-set",
@@ -1535,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.12.0"
-source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#c6d9f2ea07173cde2e03677eae9ec2b19f759bde"
+source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#77218e3bf2883765da02b33f35a63e61bdbbc4ab"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "basis-universal"
 version = "0.1.1"
-source = "git+https://github.com/expenses/basis-universal-rs#9dfe48eedda08a24f70c86dfede341654e394594"
+source = "git+https://github.com/expenses/basis-universal-rs?branch=wasm-support#8e574b16da844fd4b15af39c188c3b86d81c35d3"
 dependencies = [
  "basis-universal-sys",
  "basis-universal-wasm",
@@ -95,7 +95,7 @@ dependencies = [
 [[package]]
 name = "basis-universal-sys"
 version = "0.1.1"
-source = "git+https://github.com/expenses/basis-universal-rs#9dfe48eedda08a24f70c86dfede341654e394594"
+source = "git+https://github.com/expenses/basis-universal-rs?branch=wasm-support#8e574b16da844fd4b15af39c188c3b86d81c35d3"
 dependencies = [
  "cc",
 ]
@@ -801,6 +801,7 @@ dependencies = [
  "js-sys",
  "ktx2",
  "log",
+ "range-alloc 0.1.2 (git+https://github.com/expenses/gfx?branch=range-allocator)",
  "serde",
  "serde_json",
  "shared-structs",
@@ -1060,6 +1061,11 @@ name = "range-alloc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
+
+[[package]]
+name = "range-alloc"
+version = "0.1.2"
+source = "git+https://github.com/expenses/gfx?branch=range-allocator#6afbeb6d9733e295404f4fe0ac936591e277a26e"
 
 [[package]]
 name = "raw-window-handle"
@@ -1516,7 +1522,7 @@ dependencies = [
  "objc",
  "parking_lot",
  "profiling",
- "range-alloc",
+ "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-window-handle",
  "renderdoc-sys",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "0.12.0"
-source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#77218e3bf2883765da02b33f35a63e61bdbbc4ab"
+source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#22f8ee613415fc4f730677de848098da34ef3f35"
 dependencies = [
  "arrayvec",
  "js-sys",
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.12.0"
-source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#77218e3bf2883765da02b33f35a63e61bdbbc4ab"
+source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#22f8ee613415fc4f730677de848098da34ef3f35"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.12.0"
-source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#77218e3bf2883765da02b33f35a63e61bdbbc4ab"
+source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#22f8ee613415fc4f730677de848098da34ef3f35"
 dependencies = [
  "android-properties",
  "arrayvec",
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.12.0"
-source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#77218e3bf2883765da02b33f35a63e61bdbbc4ab"
+source = "git+https://github.com/expenses/wgpu?branch=webxr-more-extensions#22f8ee613415fc4f730677de848098da34ef3f35"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ wasm-webxr-helpers = { git = "https://github.com/expenses/wasm-webxr-helpers" }
 basis-universal-wasm = { git = "https://github.com/expenses/basis-universal-rs-wasm" }
 elsa = "1.7.0"
 anyhow = "1.0.57"
-basis-universal = { git = "https://github.com/expenses/basis-universal-rs" }
+basis-universal = { git = "https://github.com/expenses/basis-universal-rs", branch = "wasm-support" }
 zstd = { version = "0.11.2", default-features = false, features = ["wasm"] }
 wasm-futures-executor = { git = "https://github.com/wngr/wasm-futures-executor" }
 serde = { version = "1.0.137", features = ["derive"] }
@@ -40,6 +40,7 @@ serde_json = "1.0.81"
 egui-wgpu = { git = "https://github.com/expenses/egui", branch = "fixes" }
 egui = { git = "https://github.com/expenses/egui", branch = "fixes" }
 slotmap = "1.0.6"
+range-alloc = { git = "https://github.com/expenses/gfx", branch = "range-allocator" }
 
 [dependencies.web-sys]
 version = "0.3.57"

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -333,7 +333,7 @@ pub(crate) struct Model {
     pub(crate) alpha_clipped_primitives: Vec<ModelPrimitive>,
     pub(crate) opaque_double_sided_primitives: Vec<ModelPrimitive>,
     pub(crate) alpha_clipped_double_sided_primitives: Vec<ModelPrimitive>,
-    pub(crate) vertex_buffer_range: Range<u32>,
+    pub(crate) _vertex_buffer_range: Range<u32>,
     pub(crate) indices: wgpu::Buffer,
     // todo: use indices ranges for opaque and alpha clipped models.
     pub(crate) num_indices: u32,
@@ -535,7 +535,7 @@ pub(crate) async fn load_gltf_from_bytes(
         alpha_clipped_primitives,
         alpha_clipped_double_sided_primitives,
         num_indices: indices.len() as u32,
-        vertex_buffer_range,
+        _vertex_buffer_range: vertex_buffer_range,
         indices: context
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -1,0 +1,324 @@
+use std::mem::size_of;
+use std::ops::Range;
+
+use super::Instance;
+use glam::{Vec2, Vec3};
+
+pub(crate) type InstanceBuffer = VecGpuBuffer<Instance>;
+
+pub(crate) struct VecGpuBuffer<T: bytemuck::Pod> {
+    offset: u32,
+    capacity: u32,
+    pub(crate) buffer: wgpu::Buffer,
+    usage: wgpu::BufferUsages,
+    _phantom: std::marker::PhantomData<T>,
+    label: &'static str,
+}
+
+impl<T: bytemuck::Pod> VecGpuBuffer<T> {
+    fn size_in_bytes(size: u32) -> u64 {
+        size as u64 * size_of::<T>() as u64
+    }
+
+    pub(crate) fn new(
+        capacity: u32,
+        device: &wgpu::Device,
+        usage: wgpu::BufferUsages,
+        label: &'static str,
+    ) -> Self {
+        Self {
+            offset: Default::default(),
+            capacity,
+            buffer: device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(label),
+                size: Self::size_in_bytes(capacity),
+                usage: usage | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            }),
+            usage,
+            label,
+            _phantom: Default::default(),
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.offset = 0;
+    }
+
+    pub(crate) fn push(
+        &mut self,
+        instances: &[T],
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        command_encoder: &mut wgpu::CommandEncoder,
+    ) -> Range<u32> {
+        let start = self.offset;
+        let end = start + instances.len() as u32;
+
+        if end > self.capacity {
+            self.resize(end, device, command_encoder);
+        }
+
+        queue.write_buffer(
+            &self.buffer,
+            Self::size_in_bytes(start),
+            bytemuck::cast_slice(instances),
+        );
+
+        self.offset = end;
+
+        start..end
+    }
+
+    fn resize(
+        &mut self,
+        required_capacity: u32,
+        device: &wgpu::Device,
+        command_encoder: &mut wgpu::CommandEncoder,
+    ) {
+        let copy_size = Self::size_in_bytes(self.offset);
+
+        let new_capacity = required_capacity.max(self.capacity * 2);
+
+        let new_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(self.label),
+            size: Self::size_in_bytes(new_capacity),
+            usage: self.usage | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        command_encoder.copy_buffer_to_buffer(&self.buffer, 0, &new_buffer, 0, copy_size);
+
+        self.buffer = new_buffer;
+        self.capacity = new_capacity;
+    }
+}
+
+pub(crate) struct IndexBuffer {
+    allocator: range_alloc::RangeAllocator<u32>,
+    buffer: wgpu::Buffer,
+}
+
+impl IndexBuffer {
+    fn size_in_bytes(size: u32) -> u64 {
+        size as u64 * size_of::<u32>() as u64
+    }
+
+    pub(crate) fn new(capacity: u32, device: &wgpu::Device) -> Self {
+        Self {
+            allocator: range_alloc::RangeAllocator::new(0..capacity),
+            buffer: device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("index buffer"),
+                size: Self::size_in_bytes(capacity),
+                usage: wgpu::BufferUsages::INDEX
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::COPY_SRC,
+                mapped_at_creation: false,
+            }),
+        }
+    }
+
+    fn insert(
+        &mut self,
+        indices: &[u32],
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        command_encoder: &mut wgpu::CommandEncoder,
+    ) -> Range<u32> {
+        let length = indices.len() as u32;
+
+        let range = match self.allocator.allocate_range(length) {
+            Ok(range) => range,
+            Err(_) => {
+                self.resize(length, device, command_encoder);
+                self.allocator.allocate_range(length).expect("just resized")
+            }
+        };
+
+        queue.write_buffer(
+            &self.buffer,
+            Self::size_in_bytes(range.start),
+            bytemuck::cast_slice(indices),
+        );
+
+        range
+    }
+
+    fn resize(
+        &mut self,
+        required_capacity: u32,
+        device: &wgpu::Device,
+        command_encoder: &mut wgpu::CommandEncoder,
+    ) {
+        let old_capacity = self.allocator.initial_range().end;
+
+        let new_capacity = (old_capacity + required_capacity).max(old_capacity * 2);
+
+        log::info!(
+            "Growing index buffer from {} to {}",
+            old_capacity,
+            new_capacity
+        );
+
+        self.allocator.grow_to(new_capacity);
+
+        let new_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("index buffer"),
+            size: Self::size_in_bytes(new_capacity),
+            usage: wgpu::BufferUsages::INDEX
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+
+        command_encoder.copy_buffer_to_buffer(
+            &self.buffer,
+            0,
+            &new_buffer,
+            0,
+            Self::size_in_bytes(old_capacity),
+        );
+
+        self.buffer = new_buffer;
+    }
+}
+
+pub(crate) struct VertexBuffers {
+    allocator: range_alloc::RangeAllocator<u32>,
+    pub(crate) position: wgpu::Buffer,
+    pub(crate) normal: wgpu::Buffer,
+    pub(crate) uv: wgpu::Buffer,
+}
+
+impl VertexBuffers {
+    fn size_in_bytes(size: u32, size_of_field: usize) -> u64 {
+        size as u64 * size_of_field as u64
+    }
+
+    fn create_buffer(
+        device: &wgpu::Device,
+        label: &str,
+        capacity: u32,
+        size_of_field: usize,
+    ) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size: Self::size_in_bytes(capacity, size_of_field),
+            usage: wgpu::BufferUsages::VERTEX
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        })
+    }
+
+    pub(crate) fn new(capacity: u32, device: &wgpu::Device) -> Self {
+        Self {
+            allocator: range_alloc::RangeAllocator::new(0..capacity),
+            position: Self::create_buffer(device, "position buffer", capacity, size_of::<Vec3>()),
+            normal: Self::create_buffer(device, "normal buffer", capacity, size_of::<Vec3>()),
+            uv: Self::create_buffer(device, "normal buffer", capacity, size_of::<Vec2>()),
+        }
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        positions: &[Vec3],
+        normals: &[Vec3],
+        uvs: &[Vec2],
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        command_encoder: &mut wgpu::CommandEncoder,
+    ) -> Range<u32> {
+        let length = positions.len() as u32;
+
+        debug_assert_eq!(positions.len(), normals.len());
+        debug_assert_eq!(positions.len(), uvs.len());
+
+        let range = match self.allocator.allocate_range(length) {
+            Ok(range) => range,
+            Err(_) => {
+                self.resize(length, device, command_encoder);
+                self.allocator.allocate_range(length).expect("just resized")
+            }
+        };
+
+        queue.write_buffer(
+            &self.position,
+            Self::size_in_bytes(range.start, size_of::<Vec3>()),
+            bytemuck::cast_slice(positions),
+        );
+
+        queue.write_buffer(
+            &self.normal,
+            Self::size_in_bytes(range.start, size_of::<Vec3>()),
+            bytemuck::cast_slice(normals),
+        );
+
+        queue.write_buffer(
+            &self.uv,
+            Self::size_in_bytes(range.start, size_of::<Vec2>()),
+            bytemuck::cast_slice(uvs),
+        );
+
+        range
+    }
+
+    fn resize(
+        &mut self,
+        required_capacity: u32,
+        device: &wgpu::Device,
+        command_encoder: &mut wgpu::CommandEncoder,
+    ) {
+        let copy_range = self
+            .allocator
+            .allocated_ranges()
+            .last()
+            .map(|range| range.end)
+            .unwrap_or(0);
+
+        let old_capacity = self.allocator.initial_range().end;
+
+        let new_capacity = (old_capacity + required_capacity).max(old_capacity * 2);
+
+        log::info!(
+            "Growing vertex buffers from {} to {}",
+            old_capacity,
+            new_capacity
+        );
+
+        self.allocator.grow_to(new_capacity);
+
+        let new_position_buffer =
+            Self::create_buffer(&device, "position buffer", new_capacity, size_of::<Vec3>());
+        let new_normal_buffer =
+            Self::create_buffer(&device, "normal buffer", new_capacity, size_of::<Vec3>());
+        let new_uv_buffer =
+            Self::create_buffer(&device, "uv buffer", new_capacity, size_of::<Vec2>());
+
+        command_encoder.copy_buffer_to_buffer(
+            &self.position,
+            0,
+            &new_position_buffer,
+            0,
+            Self::size_in_bytes(copy_range, size_of::<Vec3>()),
+        );
+        command_encoder.copy_buffer_to_buffer(
+            &self.normal,
+            0,
+            &new_normal_buffer,
+            0,
+            Self::size_in_bytes(copy_range, size_of::<Vec3>()),
+        );
+        command_encoder.copy_buffer_to_buffer(
+            &self.uv,
+            0,
+            &new_uv_buffer,
+            0,
+            Self::size_in_bytes(copy_range, size_of::<Vec2>()),
+        );
+
+        self.position = new_position_buffer;
+        self.normal = new_normal_buffer;
+        self.uv = new_uv_buffer;
+    }
+}

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -94,13 +94,11 @@ impl<T: bytemuck::Pod> VecGpuBuffer<T> {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) struct IndexBuffer {
     allocator: range_alloc::RangeAllocator<u32>,
     pub(crate) buffer: wgpu::Buffer,
 }
 
-#[allow(dead_code)]
 impl IndexBuffer {
     fn size_in_bytes(size: u32) -> u64 {
         size as u64 * size_of::<u32>() as u64
@@ -120,7 +118,7 @@ impl IndexBuffer {
         }
     }
 
-    fn insert(
+    pub(crate) fn insert(
         &mut self,
         indices: &[u32],
         device: &wgpu::Device,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ use futures::FutureExt;
 use glam::{Mat4, Vec3};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::mem::size_of;
 use std::ops::Range;
 use std::rc::Rc;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -713,7 +712,7 @@ pub async fn run() -> Result<(), wasm_bindgen::JsValue> {
                 if let Some((x, y)) = axes
                     .get(2)
                     .as_f64()
-                    .and_then(|x| axes.get(3).as_f64().map(|y| ((x, y))))
+                    .and_then(|x| axes.get(3).as_f64().map(|y| (x, y)))
                 {
                     if i == 0 {
                         *movement.borrow_mut() =


### PR DESCRIPTION
Todo: test on Chrome on windows because it's a bit pickier about these sorts of things.